### PR TITLE
Cria fluxo buscar usuário por email

### DIFF
--- a/src/main/java/br/com/challengedropbox/commons/enums/ErrorException.java
+++ b/src/main/java/br/com/challengedropbox/commons/enums/ErrorException.java
@@ -15,6 +15,7 @@ public enum ErrorException {
     USER_NOT_FOUND("4", "Usuário não encontrado"),
     EMAIL_USER_EXISTS("5", "Email informado já cadastrado"),
     VALIDATION_ERROR("6", "Erro na válidação dos dados do usuário"),
+    USER_NOT_EXISTS("7", "Usuário informado não encontrado ou não existe"),
     ;
 
     private final String code;

--- a/src/main/java/br/com/challengedropbox/commons/exceptions/user/ErrorUserNotExists.java
+++ b/src/main/java/br/com/challengedropbox/commons/exceptions/user/ErrorUserNotExists.java
@@ -1,0 +1,13 @@
+package br.com.challengedropbox.commons.exceptions.user;
+
+import br.com.challengedropbox.commons.enums.ErrorException;
+import br.com.challengedropbox.commons.exceptions.AppException;
+import org.springframework.http.HttpStatus;
+
+public class ErrorUserNotExists extends AppException {
+
+    public ErrorUserNotExists() {
+        super(ErrorException.USER_NOT_EXISTS, HttpStatus.NOT_FOUND, null);
+    }
+
+}

--- a/src/main/java/br/com/challengedropbox/contract/v1/user/UserRestController.java
+++ b/src/main/java/br/com/challengedropbox/contract/v1/user/UserRestController.java
@@ -6,11 +6,9 @@ import br.com.challengedropbox.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @AllArgsConstructor
@@ -24,6 +22,12 @@ public class UserRestController {
     @Operation(description = "Criar usuário")
     public UserResponse createUser(@RequestBody @Valid UserRequest user) {
         return userService.createUser(user);
+    }
+
+    @GetMapping
+    @Operation(description = "Busca usuário por email")
+    public UserResponse findByEmail(@RequestParam @Email(message = "Email inválido") String email) {
+        return userService.findByEmail(email);
     }
 
 }

--- a/src/main/java/br/com/challengedropbox/service/user/UserService.java
+++ b/src/main/java/br/com/challengedropbox/service/user/UserService.java
@@ -2,11 +2,13 @@ package br.com.challengedropbox.service.user;
 
 import br.com.challengedropbox.commons.exceptions.user.ErrorSaveUserException;
 import br.com.challengedropbox.commons.exceptions.user.ErrorUserExists;
+import br.com.challengedropbox.commons.exceptions.user.ErrorUserNotExists;
 import br.com.challengedropbox.mapper.user.UserEntityToResponseMapper;
 import br.com.challengedropbox.mapper.user.UserRequestToEntityMapper;
 import br.com.challengedropbox.model.user.request.UserRequest;
 import br.com.challengedropbox.model.user.response.UserResponse;
 import br.com.challengedropbox.repository.user.UserRepository;
+import br.com.challengedropbox.repository.user.entity.UserEntity;
 import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.stereotype.Service;
@@ -56,6 +58,21 @@ public class UserService {
         } catch (NoSuchAlgorithmException e) {
             throw new ErrorSaveUserException();
         }
+    }
+
+    public UserResponse findByEmail(String email) {
+        return Optional.ofNullable(email)
+            .map(this::validadeUserNotExists)
+            .map(UserEntityToResponseMapper::toResponse)
+            .orElseThrow();
+    }
+
+    private UserEntity validadeUserNotExists(String email) {
+        var existsUser = userRepository.findByEmail(email);
+        if (ObjectUtils.isEmpty(existsUser)) {
+            throw new ErrorUserNotExists();
+        }
+        return existsUser;
     }
 
 }


### PR DESCRIPTION
Cria validação e fluxo para buscar usuário por email

## Exemplo de request
```
curl -X 'GET' \
  'http://localhost:9000/challengedropbox/v1/users?email=teste%40teste.com' \
  -H 'accept: */*'
```
## Exemplo de response
```
{
  "id": "67cf34f80405e86906dcc7e0",
  "name": "teste",
  "email": "teste@teste.com"
}
```

#2 

Closes: #2 