### PR TITLE
Adiciona fluxo de buscar todos usuários

### DIFF
--- a/src/main/java/br/com/challengedropbox/contract/v1/user/UserRestController.java
+++ b/src/main/java/br/com/challengedropbox/contract/v1/user/UserRestController.java
@@ -10,6 +10,8 @@ import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @AllArgsConstructor
 @RequestMapping("/v1/users")
@@ -28,6 +30,12 @@ public class UserRestController {
     @Operation(description = "Busca usuário por email")
     public UserResponse findByEmail(@RequestParam @Email(message = "Email inválido") String email) {
         return userService.findByEmail(email);
+    }
+
+    @GetMapping("/all")
+    @Operation(description = "")
+    public List<UserResponse> findAllUsers() {
+        return userService.findAllUsers();
     }
 
 }

--- a/src/main/java/br/com/challengedropbox/mapper/user/ListUserEntityToResponseMapper.java
+++ b/src/main/java/br/com/challengedropbox/mapper/user/ListUserEntityToResponseMapper.java
@@ -1,0 +1,20 @@
+package br.com.challengedropbox.mapper.user;
+
+import br.com.challengedropbox.model.user.response.UserResponse;
+import br.com.challengedropbox.repository.user.entity.UserEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+@Mapper
+public interface ListUserEntityToResponseMapper {
+
+    static List<UserResponse> toListResponse(List<UserEntity> userEntity) {
+        return Mappers.getMapper(ListUserEntityToResponseMapper.class)
+            .mapper(userEntity);
+    }
+
+    List<UserResponse> mapper(List<UserEntity> userEntity);
+
+}

--- a/src/main/java/br/com/challengedropbox/service/user/UserService.java
+++ b/src/main/java/br/com/challengedropbox/service/user/UserService.java
@@ -3,6 +3,7 @@ package br.com.challengedropbox.service.user;
 import br.com.challengedropbox.commons.exceptions.user.ErrorSaveUserException;
 import br.com.challengedropbox.commons.exceptions.user.ErrorUserExists;
 import br.com.challengedropbox.commons.exceptions.user.ErrorUserNotExists;
+import br.com.challengedropbox.mapper.user.ListUserEntityToResponseMapper;
 import br.com.challengedropbox.mapper.user.UserEntityToResponseMapper;
 import br.com.challengedropbox.mapper.user.UserRequestToEntityMapper;
 import br.com.challengedropbox.model.user.request.UserRequest;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -73,6 +75,10 @@ public class UserService {
             throw new ErrorUserNotExists();
         }
         return existsUser;
+    }
+
+    public List<UserResponse> findAllUsers() {
+        return ListUserEntityToResponseMapper.toListResponse(userRepository.findAll());
     }
 
 }


### PR DESCRIPTION
Cria endpoint e fluxo buscar todos os usuários cadastrados

## Exemplo de request
```
curl -X 'GET' \
  'http://localhost:9000/challengedropbox/v1/users/all' \
  -H 'accept: */*'
```

## Exemplo de response
```
[
  {
    "id": "67cf34f80405e86906dcc7e0",
    "name": "teste",
    "email": "teste@teste.com"
  },
  {
    "id": "67cf6177e2af215b7bc4ce62",
    "name": "string",
    "email": "string@string.com"
  }
]
```

Closes: #3 